### PR TITLE
一部のデバイスで重力なしの加速度が取得できない場合に対応

### DIFF
--- a/gallery/meganetaaan/pump/js/ShakeController.js
+++ b/gallery/meganetaaan/pump/js/ShakeController.js
@@ -37,6 +37,11 @@
 
             // （重力加速度を除外した）加速度
             var ac = context.event.originalEvent.acceleration;
+
+            // NOTE: デバイスによってaccelerationが取得できない（値にnullが入る）事象への暫定対処
+            if (ac.x == null) {
+                ac = context.event.originalEvent.accelerationIncludingGravity;
+            }
             var score = this._magnitude(ac);
 
             context.event.preventDefault();


### PR DESCRIPTION
一部のデバイスでdevicemotion時のevent.acceleration.[x|y|z] にnullが入ることがある。
その場合はaccelerationIncludingGravityで代用することにした。